### PR TITLE
Added ability to run in linux

### DIFF
--- a/bench/compare2.sh
+++ b/bench/compare2.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 
-source ~/lamatune/bench/config.sh
-source ~/lamatune/bench/funcs.sh
-
-# source ./bench/config.sh
-# source ./bench/funcs.sh
-
-# This version gives an error saying path doesn't exist
-# source ./config.sh
-# source ./funcs.sh 
+source ./config.sh
+source ./funcs.sh 
 
 export tempdir='/tmp'
 pushd .

--- a/bench/compare2.sh
+++ b/bench/compare2.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-source ./config.sh
-source ./funcs.sh
+source ~/lamatune/bench/config.sh
+source ~/lamatune/bench/funcs.sh
+
+# source ./bench/config.sh
+# source ./bench/funcs.sh
+
+# This version gives an error saying path doesn't exist
+# source ./config.sh
+# source ./funcs.sh 
 
 export tempdir='/tmp'
 pushd .
@@ -42,37 +49,30 @@ run_v2() {
 run_checkout
 
 run_setup() {
-  if [ "$1" == "v1" ]; then
-    cd $tempdir/v1/
-    mojo build llama2.mojo
-  elif [ "$1" == "v2" ]; then
-    cd $tempdir/v2/
-    mojo build llama2.mojo
-  fi;
+  cd $tempdir/$1/
+  mojo build llama2.mojo
 }
 
 export -f run_v1
 export -f run_v2
 export -f run_setup
 
-run_setup v1
-# if exit code is not 0, exit
-if [ $? -ne 0 ]; then
-  echo "Error building v1"
-  exit 1
-fi
+IMPLEMENTATIONS=('v1' 'v2')
 
-run_setup v2
-# if exit code is not 0, exit
-if [ $? -ne 0 ]; then
-  echo "Error building v2"
-  exit 1
-fi
+# Loop through all versions in IMPLEMENTATIONS and set them up
+for ver in "${IMPLEMENTATIONS[@]}"; do
+  run_setup "$ver"
 
-IMPLEMENTATIONS='v1,v2'
-PARAM_MODELS='stories15M.bin,stories42M.bin,stories110M.bin'
+  if [ $? -ne 0 ]; then
+    echo "Error building $ver"
+    exit 1
+  fi
+done
 
-hypertune "run_{ver} {model}" \
+IMPLEMENTATIONS="v1,v2"
+PARAM_MODELS="stories15M.bin,stories42M.bin,stories110M.bin"
+
+hypertune --shell=bash "run_{ver} {model}" \
 -L ver $IMPLEMENTATIONS -L model $PARAM_MODELS \
 --output=report \
 --export-json=/tmp/compare2.json \

--- a/bench/funcs.sh
+++ b/bench/funcs.sh
@@ -13,7 +13,14 @@ run_cmd() {
 
 gen_report() {
   RESULTS="$1"
-  RESID=$(md5 -r $RESULTS | cut -c1-4)
+  if [[ $(uname) == "Darwin" ]]; then
+    # macOS (BSD sed)
+    RESID=$(md5 -r $RESULTS | cut -c1-4)
+  else
+    # Linux (GNU sed)
+    RESID=$(md5sum $RESULTS | cut -c1-4)
+  fi
+
   REPORT="/tmp/hypertune-report-$RESID.html"
   echo "" > $REPORT
   LN=$(grep -Fn "'---DATA_POINTS---';" $REPORT_TEMPLATE | cut -d':' -f1)
@@ -40,7 +47,13 @@ gen_report() {
   REPL='s#'$ORIGINAL_STR'#'$VERSIONS_STR'#g'
 
   # replace "<!-- VERSIONS -->" to a string $VERSIONS_STR
-  sed -i '.bak' "$REPL" $REPORT
+  if [[ $(uname) == "Darwin" ]]; then
+    # macOS (BSD sed)
+    sed -i '.bak' "$REPL" $REPORT
+  else
+      # Linux (GNU sed)
+      sed -i "$REPL" "$REPORT"
+  fi
 
   echo $REPORT
 }

--- a/bench/funcs.sh
+++ b/bench/funcs.sh
@@ -14,10 +14,10 @@ run_cmd() {
 gen_report() {
   RESULTS="$1"
   if [[ $(uname) == "Darwin" ]]; then
-    # macOS (BSD sed)
+    # macOS (BSD md5)
     RESID=$(md5 -r $RESULTS | cut -c1-4)
   else
-    # Linux (GNU sed)
+    # Linux (GNU md5)
     RESID=$(md5sum $RESULTS | cut -c1-4)
   fi
 


### PR DESCRIPTION
To be able to run the script in linux:
1. I had to change the funcs.sh script, the implementation of sed in bsd and gnu seem to have different commands, and for the md5 i also had to change this to instead use md5sum (this is the function included in gnu)
2. For the compare2.sh, i had to change the hypertune command to use the bash shell, i don't understand why with the original implementation, hypertune would give an error saying that run_v1 or run_v2 doesn't exist, (it seems it would run the command in a different shell session?), and I couldn't find another way to fix it.
3. The last thing is that at least for me, to be able to run the script i had to be in the bench directory, if run the command bash bench/compar2.sh, i would get an error saying that config.sh and funcs.sh doesn't exist

From what i understand this changes should still be able to run in mac and in other linux computers ( I tested this script on Pop_os)